### PR TITLE
Creation of dynamic property Javanile\Imap2\Roundcube\ImapClient::$user is deprecated

### DIFF
--- a/src/Roundcube/ImapClient.php
+++ b/src/Roundcube/ImapClient.php
@@ -61,6 +61,7 @@ class ImapClient
 
     protected $fp;
     protected $host;
+    protected $user;
     protected $cmd_tag;
     protected $cmd_num = 0;
     protected $resourceid;


### PR DESCRIPTION
```
  [Ddeboer\Imap\Exception\AuthenticationFailedException (8192)]
  [E_DEPRECATED] Authentication failed for user "email@domain.com": Creation of dynamic property Javanile\Imap2\Roundcube\ImapClient::$user is deprecated
  imap2_alerts (0):
  imap2_errors (0):

Exception trace:
  at /vendor/mugonix/imap/src/Server.php:87
```

The ImapClient::connect() method assign's a property user but it is not defined as a class property.